### PR TITLE
kubernetes-volumes full task

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,3 +328,39 @@ kubectl describe secret kubernetes-dashboard-token-t5qnb -n kubernetes-dashboard
 - Получение адреса minikube: minikube ip
 
 </details>
+
+<details>
+<summary>Домашнее задание к лекции №6 (Хранение данных в Kubernetes: Volumes, Storages, Statefull-приложения)
+</summary>
+
+### Задание:
+
+- Запущен кластен через kind
+- Установлен MinIO (https://min.io) statefulset и service с использованием их манифестов:
+
+```
+kubectl apply -f https://raw.githubusercontent.com/express42/otus-platformsnippets/master/Module-02/Kuberenetes-volumes/minio-statefulset.yaml
+kubectl apply -f https://raw.githubusercontent.com/express42/otus-platformsnippets/master/Module-02/Kuberenetes-volumes/minio-headless-service.yaml
+```
+
+- Манифесты сохранены в каталог: ./kubernetes-volumes
+- Замучаны pv и pvc в разных способах создания и удаления, а также применения политик.
+- Изучено как это хранится на диске с учетом stadard плагина kind и minikube
+- Для запуска minio можно использовать: kubectl port-forward statefulsets/minio 9000:9000
+- Опробовано использование самого minio
+- На будущее есть некая то ли фича, то ли баг(по крайней мере офф документации k8s поведение явно противоречит, то это же плагин :) ):
+
+>Интересный момент поймал на kind(да и minikube также ведет себя) с volume(домашка с minio): 
+>если попытаться удалить PV(policy deleted) при существующем PVC, PV перейдет в terminated 
+>как описано например тут https://kubernetes.io/docs/concepts/storage/persistent-volumes/#storage-object-in-use-protection), 
+>но когда удалить PVC после этого, PV удалится, но данные по факту останутся в каталоге докера(в volumes) несмотря на политику. 
+>Если же удалить изначально PVC, то и PV и данные удалятся(считаем что сам ss minio во всех случаях уже убит).  
+
+### Задание со *
+
+>В конфигурации нашего StatefulSet данные указаны в открытом виде, что не безопасно.
+> Поместите данные в и настройте конфигурацию на их использование.
+
+Написан манифест для secret. Сами secret закодированы base64. В существующие манифест statefulset добавлено использование secret.
+
+</details>

--- a/kubernetes-volumes/minio-headless-service.yaml
+++ b/kubernetes-volumes/minio-headless-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  labels:
+    app: minio
+spec:
+  clusterIP: None
+  ports:
+    - port: 9000
+      name: minio
+  selector:
+    app: minio

--- a/kubernetes-volumes/minio-secret.yaml
+++ b/kubernetes-volumes/minio-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-secret
+type: Opaque
+data:
+  MINIO_ACCESS_KEY: bWluaW8=
+  MINIO_SECRET_KEY: bWluaW8xMjM=

--- a/kubernetes-volumes/minio-statefulset.yaml
+++ b/kubernetes-volumes/minio-statefulset.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  # This name uniquely identifies the StatefulSet
+  name: minio
+spec:
+  serviceName: minio
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio # has to match .spec.template.metadata.labels
+  template:
+    metadata:
+      labels:
+        app: minio # has to match .spec.selector.matchLabels
+    spec:
+      containers:
+      - name: minio
+        env:
+        - name: MINIO_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: minio-secret
+              key: MINIO_ACCESS_KEY
+          #value: "minio"
+        - name: MINIO_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: minio-secret
+              key: MINIO_SECRET_KEY
+          #value: "minio123"
+        image: minio/minio:RELEASE.2019-07-10T00-34-56Z
+        args:
+        - server
+        - /data 
+        ports:
+        - containerPort: 9000
+        # These volume mounts are persistent. Each pod in the PetSet
+        # gets a volume mounted based on this field.
+        volumeMounts:
+        - name: data
+          mountPath: /data
+        # Liveness probe detects situations where MinIO server instance
+        # is not working properly and needs restart. Kubernetes automatically
+        # restarts the pods if liveness checks fail.
+        livenessProbe:
+          httpGet:
+            path: /minio/health/live
+            port: 9000
+          initialDelaySeconds: 120
+          periodSeconds: 20
+  # These are converted to volume claims by the controller
+  # and mounted at the paths mentioned above. 
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi


### PR DESCRIPTION
# Выполнено ДЗ № 6

 - [X] Основное ДЗ
 - [X] Задание со *

## В процессе сделано:
- Запущен кластер через kind
- Установлен MinIO (https://min.io) statefulset и service с использованием их манифестов.
- Манифесты сохранены в каталог: ./kubernetes-volumes
- Замучаны pv и pvc в разных способах создания и удаления, а также применения политик.
- Изучено как это хранится на диске с учетом stadard плагина kind и minikube
- Для запуска minio можно использовать: kubectl port-forward statefulsets/minio 9000:9000
- Опробовано использование самого minio
- Написан манифест для secret. Сами secret закодированы base64. В существующие манифест statefulset добавлено использование secret.

## Как запустить проект:
 - В каталоге kubernetes-volumes: kubectl apply -f ./

## Как проверить работоспособность:
 - выполнить: kubectl port-forward statefulsets/minio 9000:9000
 - далее по ссылке http://localhost:9000
 - проверить volume и прочее:
```
kubectl get statefulsets
kubectl get pods
kubectl get pvc
kubectl get pv
kubectl describe <resource> <resource_name>
```

## PR checklist:
 - [X] Выставлен label с темой домашнего задания
