### PR TITLE
HW22 - add main task

### DIFF
--- a/README.md
+++ b/README.md
@@ -1732,3 +1732,4 @@ root@VirtualBox:/home/docker/volumes/minikube/_data/lib/csi-hostpath-data# ls
 ```
 
 </details>
+

--- a/kubernetes-storage/hw/01-storageclass.yaml
+++ b/kubernetes-storage/hw/01-storageclass.yaml
@@ -1,0 +1,7 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: csi-hostpath-sc
+provisioner: hostpath.csi.k8s.io
+reclaimPolicy: Delete
+volumeBindingMode: Immediate

--- a/kubernetes-storage/hw/02-pvc.yaml
+++ b/kubernetes-storage/hw/02-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: storage-pvc
+spec:
+  storageClassName: csi-hostpath-sc
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+

--- a/kubernetes-storage/hw/03-pod.yaml
+++ b/kubernetes-storage/hw/03-pod.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: storage-pod
+spec:
+  containers:
+  - name: storage-test
+    image: nginx:stable-alpine
+    volumeMounts:
+    - name: data
+      mountPath: "/data"
+  volumes:
+  - name: data
+    persistentVolumeClaim:
+      claimName: storage-pvc

--- a/kubernetes-storage/hw/04-snapshot.yaml
+++ b/kubernetes-storage/hw/04-snapshot.yaml
@@ -1,0 +1,8 @@
+apiVersion: snapshot.storage.k8s.io/v1beta1
+kind: VolumeSnapshot
+metadata:
+  name: storage-snapshot
+spec:
+  volumeSnapshotClassName: csi-hostpath-snapclass
+  source: 
+    persistentVolumeClaimName: storage-pvc

--- a/kubernetes-storage/hw/05-restore.yaml
+++ b/kubernetes-storage/hw/05-restore.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: storage-pvc
+spec:
+  storageClassName: csi-hostpath-sc
+  dataSource:
+    kind: VolumeSnapshot
+    name: storage-snapshot
+    apiGroup: snapshot.storage.k8s.io
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+


### PR DESCRIPTION
# Выполнено ДЗ № 22

 - [X] Основное ДЗ
 - [ ] Задание со *

## В процессе сделано:
- развернут кластер в minikube
- Установлен host path csi driver
- Написаны yaml для storageclass, pvc, pod, snapshot и restore
- все это развернуто и проверено восстановление pvc/pv из snapshot-а

## Как запустить проект:
 - запускаем minikube или берем любой кластер
 - устанавливаем сsi драйвер - подробную инструкцию смотри в readme
 - дальше из каталога kubernetes-storage устанавливаем yaml 01-03* 

## Как проверить работоспособность:
 - зайти в pod kubectl exec -it storage-pod -- sh и создать в /data что угодно
 - создать snapshot kubernetes-storage/04-snapshot.yaml
 - удалить pod и pvc, проверить что pv удалился. 
 - восстановить pvc из snapshot, применив kubernetes-storage/05-restore.yaml
 - восстановить pod kubernetes-storage/03-pod.yaml зайти в него и убедиться, что созданные элементы в /data присутствуют

## PR checklist:
 - [X] Выставлен label с темой домашнего задания
